### PR TITLE
Enable retrieval of all created alcohols

### DIFF
--- a/app/controllers/alcohol_controller.rb
+++ b/app/controllers/alcohol_controller.rb
@@ -1,6 +1,12 @@
 class AlcoholController < ApplicationController
   include AlcoholControllerHelper
 
+  def index
+    alcohols = Alcohol.all
+
+    render json: { alcohols: alcohols, total: alcohols.count }.to_json
+  end
+
   def create
     @alcohol = Alcohol.create(alcohol_params)
 
@@ -11,7 +17,6 @@ class AlcoholController < ApplicationController
     else
       render json: alcohol, status: :unprocessable_entity
     end
-
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   post "/alcohol/create", to: "alcohol#create"
+  get "/alcohol", to: "alcohol#index"
 end

--- a/spec/controllers/alcohol_controller_spec.rb
+++ b/spec/controllers/alcohol_controller_spec.rb
@@ -22,12 +22,23 @@ RSpec.describe AlcoholController, type: :controller do
       before(:each) { post :create, params: { name: '', vv: '' } }
 
       it 'returns correct errors' do
-        puts json.inspect
         expect(json['errors'].values).to include(["can't be blank"])
       end
 
       it { expect(response.status).to eq(422) }
       it { expect(Alcohol.find_by_name(name)).to be_nil }
+    end
+  end
+
+  context '.index' do
+    context 'retrieve all alcohols' do
+      before { create(:alcohol) }
+      let!(:total) { Alcohol.count }
+
+      it 'returns all alcohols' do
+        get :index
+        expect(json['total']).to eq(total)
+      end
     end
   end
 end


### PR DESCRIPTION
#### What does this PR do?
- Enable retrieval of all created alcohols

#### Description of Task to be completed?
- Add a controller to handle retrieval of all created alcohols.

#### How should this be manually tested?
- checkout into branch `ft-view-alcohols`.
- run the server 'rails s`
- open `postman`, if you don't have one [click here](https://www.getpostman.com/apps)
- enter endpoint url `http://localhost:3000/alcohol`
- make `GET` requests and you will see objects in the database.

#### What are the relevant pivotal tracker stories?
N/A

#### Any background context you want to add?
N/A

#### Screenshots
<img width="1139" alt="screen shot 2018-06-17 at 13 48 37" src="https://user-images.githubusercontent.com/15877982/41507138-2b21dca4-7235-11e8-8fb0-5249f7909d5a.png">